### PR TITLE
Premiere refonte fiche joueur

### DIFF
--- a/front/fiche_joueur.html
+++ b/front/fiche_joueur.html
@@ -29,6 +29,24 @@
     </table>
     <h2> Historique de ses combats : </h2>
     <table id="tablematch">
+        <thead>
+            <tr>
+                <th>N° match</th>
+                <th>Equipe 1</th>
+                <!-- <th></th>
+                <th></th>
+                <th></th> -->
+                <th>Score</th>
+                <th>Equipe 2</th>
+                <!-- <th></th>
+                <th></th>
+                <th></th> -->
+                <th>Date</th>
+                <th>Map</th>
+            </tr>
+        </thead>
+        <tbody id="tablematchbody">
+        </tbody>
     </table>
     <script>
         $(document).ready(function () {
@@ -131,7 +149,7 @@
 
                         }
 
-                        $('#tablematch').append(htmlscript);
+                        $('#tablematchbody').append(htmlscript);
                     });
 
                 });

--- a/front/fiche_joueur.html
+++ b/front/fiche_joueur.html
@@ -28,24 +28,18 @@
     <table id="tableelos">
     </table>
     <h2> Historique de ses combats : </h2>
-    <table id="tablematch">
+    <table id="tablematch" align="center">
         <thead>
             <tr>
                 <th>N° match</th>
                 <th>Equipe 1</th>
-                <!-- <th></th>
-                <th></th>
-                <th></th> -->
                 <th>Score</th>
                 <th>Equipe 2</th>
-                <!-- <th></th>
-                <th></th>
-                <th></th> -->
                 <th>Date</th>
                 <th>Map</th>
             </tr>
         </thead>
-        <tbody id="tablematchbody">
+        <tbody id="tablematchbody" align="center">
         </tbody>
     </table>
     <script>
@@ -93,24 +87,24 @@
                                 htmlscript += '<tr>';
                                 htmlscript += '<td>' + item.id + '</td>';
                                 // team 1
-                                htmlscript += '<td>' + joueursresponse[item.team1_player1]['pseudo'] + '</td>';
+                                htmlscript += '<td>' + joueursresponse[item.team1_player1]['pseudo'] + '<br>';
                                 if (joueursresponse[item.team1_player2]['bot']) {
-                                    htmlscript += '<td></td>';
+                                    htmlscript += '';
                                 }
                                 else {
-                                    htmlscript += '<td>' + joueursresponse[item.team1_player2]['pseudo'] + '</td>';
+                                    htmlscript += joueursresponse[item.team1_player2]['pseudo'] + '<br>';
                                 }
                                 if (joueursresponse[item.team1_player3]['bot']) {
-                                    htmlscript += '<td></td>';
+                                    htmlscript += '';
                                 }
                                 else {
-                                    htmlscript += '<td>' + joueursresponse[item.team1_player3]['pseudo'] + '</td>';
+                                    htmlscript +=  joueursresponse[item.team1_player3]['pseudo'] + '<br>';
                                 }
                                 if (joueursresponse[item.team1_player4]['bot']) {
-                                    htmlscript += '<td></td>';
+                                    htmlscript += '</td>';
                                 }
                                 else {
-                                    htmlscript += '<td>' + joueursresponse[item.team1_player4]['pseudo'] + '</td>';
+                                    htmlscript += joueursresponse[item.team1_player4]['pseudo'] + '</td>';
                                 }
                                 //the scores !!!
                                 if (item.score_team1 > item.score_team2) {
@@ -120,27 +114,29 @@
                                     htmlscript += '<td>' + item.score_team1 + "&nbsp-&nbsp;<strong>" + item.score_team2 + '</strong></td>';
                                 }
                                 //team 2
-                                htmlscript += '<td>' + joueursresponse[item.team2_player1]['pseudo'] + '</td>';
+                                htmlscript += '<td>' + joueursresponse[item.team2_player1]['pseudo'] + '<br>';
                                 if (joueursresponse[item.team2_player2]['bot']) {
-                                    htmlscript += '<td></td>';
+                                    htmlscript += '';
                                 }
                                 else {
-                                    htmlscript += '<td>' + joueursresponse[item.team2_player2]['pseudo'] + '</td>';
+                                    htmlscript += joueursresponse[item.team2_player2]['pseudo'] + '<br>';
                                 }
                                 if (joueursresponse[item.team2_player3]['bot']) {
-                                    htmlscript += '<td></td>';
+                                    htmlscript += '';
                                 }
                                 else {
-                                    htmlscript += '<td>' + joueursresponse[item.team2_player3]['pseudo'] + '</td>';
+                                    htmlscript += joueursresponse[item.team2_player3]['pseudo'] + '<br>';
                                 }
                                 if (joueursresponse[item.team2_player4]['bot']) {
-                                    htmlscript += '<td></td>';
+                                    htmlscript += '</td>';
                                 }
                                 else {
-                                    htmlscript += '<td>' + joueursresponse[item.team2_player4]['pseudo'] + '</td>';
+                                    htmlscript += joueursresponse[item.team2_player4]['pseudo'] + '</td>';
                                 }
                                 //global info
-                                htmlscript += '<td>' + item.date + '</td>';
+                                var date = new Date(item.date);
+                                var dateresult = date.getUTCDate() + '-' + (date.getUTCMonth()+1) + '-' + date.getUTCFullYear();
+                                htmlscript += '<td>' + dateresult + '</td>';
                                 htmlscript += '<td>' + item.map + '</td>';
 
                                 htmlscript += '</tr>';


### PR DESCRIPTION
Quelques modifications pour rendre le tableau de l'historique d'un combat d'un joueur plus lisible :
- ajout de titres aux colonnes
- regroupement des joueurs d'une équipe dans une seule cellule du tableau
- conversion de la date au format ISO vers une date seule au format FR (presque). L'affichage de l'heure ne semblait pas pertinent et rendait le tableau trop lourd à lire.

Pourquoi première refonte ? Parce que j'ai essayé de jouer avec le CSS pour mettre les deux tableaux de la fiche joueur côte à côte mais ce fut un échec, j'ai donc lâché l'affaire. Si @quasart peut me montrer à l'occasion comment faire, ça peut m'intéresser :)

A noter que la date affichée dans le tableau d'évolution de l'ELO a l'air de correspondre à la date de redéploiement de la database, il faudra corriger ça aussi.